### PR TITLE
Fix the makefile override in tests.yaml

### DIFF
--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -28,6 +28,10 @@ class Parser(dict):
             data = yaml.safe_load(open(path, 'r').read())
             self.merge(data)
 
+            # Replace the default makefile targets
+            if 'makefile' in data:
+                self.update(makefile=data['makefile'])
+
     def __getattr__(self, key):
         return dict.get(self, key)
 


### PR DESCRIPTION
Config merges it’s defaults against those in tests.yaml. In the case of
the makefile setting, it appends to the makefile targets to run, rather
than replacing. This can cause duplicate tests to be run and tests run
that shouldn’t be. This fix call’s update, which will replace the key
contents.
